### PR TITLE
Extrinsic hallucination

### DIFF
--- a/doc/fixes-mHack.txt
+++ b/doc/fixes-mHack.txt
@@ -17,6 +17,10 @@ Adjusted difficulty calculations to increase difficulty more steeply in a shorte
 Added des.ugname function to Lua special level loader.
 Fix for predefined corpses inside of ice boxes on special levels.
 Remove the Fake Wizard tower which does not have a magic portal.
+Hallucination no longer prevents offering the Amulet of Yendor.
+Grayswandir no longer grants hallucination resistance.
+Sunword grants hallucination resistance when wielded.
+The Heart of Ahriman grants hallucination resistance when carried.
 
 Fixes to Post-X.X.X Problems that Were Exposed Via git Repository
 ------------------------------------------------------------------
@@ -85,6 +89,10 @@ Added 3 variants of the Oracle level.
 Added 2 variants to the bottom level of the Wizard's Tower.
 Added 13 variants to the top level of the Wizard's Tower.
 Added a Mine's End variant with many gnomes and wands.
+The Amulet of Yendor grants extrinsic hallucination.
+	Extrinsic hallucination does not time out and is not cured with a unicorn horn.
+	It can be resisted with an item granting hallucination resistance.
+	It can be avoided by dropping the Amulet.
 
 Platform- and/or Interface-Specific New Features
 ------------------------------------------------

--- a/include/artilist.h
+++ b/include/artilist.h
@@ -140,7 +140,7 @@ static NEARDATA struct artifact artilist[] = {
       PHYS(5, 0), DFNS(AD_WERE), NO_CARY, 0, A_NONE, NON_PM, NON_PM, 1500L,
       NO_COLOR, WEREBANE),
 
-    A("Grayswandir", SABER, (SPFX_RESTR | SPFX_HALRES), 0, 0,
+    A("Grayswandir", SABER, (SPFX_RESTR), 0, 0,
       PHYS(5, 0), NO_DFNS, NO_CARY, 0, A_LAWFUL, NON_PM, NON_PM, 8000L,
       NO_COLOR, GRAYSWANDIR),
 
@@ -178,7 +178,7 @@ static NEARDATA struct artifact artilist[] = {
 
     /* Sunsword emits light when wielded (handled in the core rather than
        via artifact fields), but that light has no particular color */
-    A("Sunsword", LONG_SWORD, (SPFX_RESTR | SPFX_DFLAG2), 0, M2_UNDEAD,
+    A("Sunsword", LONG_SWORD, (SPFX_RESTR | SPFX_DFLAG2 | SPFX_HALRES), 0, M2_UNDEAD,
       PHYS(5, 0), DFNS(AD_BLND), NO_CARY, BLINDING_RAY, A_LAWFUL, NON_PM,
       NON_PM, 1500L, NO_COLOR, SUNSWORD),
 
@@ -192,7 +192,7 @@ static NEARDATA struct artifact artilist[] = {
       NON_PM, 2500L, NO_COLOR, ORB_OF_DETECTION),
 
     A("The Heart of Ahriman", LUCKSTONE,
-      (SPFX_NOGEN | SPFX_RESTR | SPFX_INTEL), SPFX_STLTH, 0,
+      (SPFX_NOGEN | SPFX_RESTR | SPFX_INTEL), (SPFX_STLTH | SPFX_HALRES), 0,
       /* this stone does double damage if used as a projectile weapon */
       PHYS(5, 0), NO_DFNS, NO_CARY, LEVITATION, A_NEUTRAL, PM_BARBARIAN,
       NON_PM, 2500L, NO_COLOR, HEART_OF_AHRIMAN),

--- a/include/extern.h
+++ b/include/extern.h
@@ -2448,6 +2448,7 @@ extern void make_stoned_material(long, const char *, int, const char *, int) NO_
 extern void make_vomiting(long, boolean);
 extern void make_blinded(long, boolean);
 extern void toggle_blindness(void);
+extern void make_divine_hallucinated(boolean);
 extern boolean make_hallucinated(long, boolean, long);
 extern void make_deaf(long, boolean);
 extern void make_glib(int);

--- a/include/youprop.h
+++ b/include/youprop.h
@@ -112,12 +112,13 @@
 #define Glib u.uprops[GLIB].intrinsic
 #define Slimed u.uprops[SLIMED].intrinsic /* [Tom] */
 
-/* Hallucination is solely a timeout */
+/* Timeout, plus a worn mask */
 #define HHallucination u.uprops[HALLUC].intrinsic
+#define EHallucination u.uprops[HALLUC].extrinsic
 #define HHalluc_resistance u.uprops[HALLUC_RES].intrinsic
 #define EHalluc_resistance u.uprops[HALLUC_RES].extrinsic
 #define Halluc_resistance (HHalluc_resistance || EHalluc_resistance)
-#define Hallucination (HHallucination && !Halluc_resistance)
+#define Hallucination ((HHallucination || EHallucination) && !Halluc_resistance)
 
 /* Timeout, plus a worn mask */
 #define HDeaf u.uprops[DEAF].intrinsic

--- a/src/invent.c
+++ b/src/invent.c
@@ -976,6 +976,7 @@ addinv_core1(struct obj *obj)
         if (u.uhave.amulet)
             impossible("already have amulet?");
         u.uhave.amulet = 1;
+        make_divine_hallucinated(1);
         record_achievement(ACH_AMUL);
     } else if (obj->otyp == CANDELABRUM_OF_INVOCATION) {
         if (u.uhave.menorah)
@@ -1337,6 +1338,7 @@ freeinv_core(struct obj *obj)
         if (!u.uhave.amulet)
             impossible("don't have amulet?");
         u.uhave.amulet = 0;
+        make_divine_hallucinated(0);
     } else if (obj->otyp == CANDELABRUM_OF_INVOCATION) {
         if (!u.uhave.menorah)
             impossible("don't have candelabrum?");

--- a/src/potion.c
+++ b/src/potion.c
@@ -471,7 +471,7 @@ make_hallucinated(
                 if (eyecount(gy.youmonst.data) != 1)
                     eyes = makeplural(eyes);
                 Your(eyemsg, eyes, vtense(eyes, "itch"));
-            } else { /* Grayswandir */
+            } else { /* From an artifact or scales */
                 Your(vismsg, "flatten", "normal");
             }
         }

--- a/src/pray.c
+++ b/src/pray.c
@@ -1817,7 +1817,7 @@ dosacrifice(void)
         You("are not %s an altar.",
             (Levitation || Flying) ? "over" : "on");
         return ECMD_OK;
-    } else if (Confusion || Stunned || Hallucination) {
+    } else if (Confusion || Stunned) {
         You("are too impaired to perform the rite.");
         return ECMD_OK;
     }


### PR DESCRIPTION
The Amulet of Yendor causes hallucination, which is only truly curable by letting go of it. It can be resisted with hallucination resistance. Sources of hallucination resistance are changed for game balance reasons. Offering the amulet while hallucinating is allowed.